### PR TITLE
Add web3 balance indicators

### DIFF
--- a/src/stores/ForeignStore.js
+++ b/src/stores/ForeignStore.js
@@ -13,6 +13,7 @@ import {
   getSymbol,
   getMessage
 } from './utils/contract'
+import { balanceLoaded, removePendingTransaction } from './utils/testUtils'
 
 async function asyncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
@@ -112,6 +113,7 @@ class ForeignStore {
         } else {
           this.balance = `Please point metamask to ${this.web3Store.foreignNet.name}\n`
         }
+        balanceLoaded()
       })
     } catch(e) {
       console.error(e)
@@ -141,6 +143,10 @@ class ForeignStore {
           this.alertStore.pushSuccess(`Tokens received on ${this.web3Store.foreignNet.name} for Tx ${event.returnValues.transactionHash}`)
           this.waitingForConfirmation.delete(event.returnValues.transactionHash)
         })
+
+        if(confirmationEvents.length) {
+          removePendingTransaction()
+        }
       }
 
       return events

--- a/src/stores/HomeStore.js
+++ b/src/stores/HomeStore.js
@@ -2,6 +2,7 @@ import { action, observable } from 'mobx';
 import HOME_ABI from '../abis/HomeBridge.json';
 import { getBlockNumber, getBalance } from './utils/web3'
 import { getMaxPerTxLimit, getMinPerTxLimit, getCurrentLimit, getPastEvents } from './utils/contract'
+import { removePendingTransaction } from './utils/testUtils'
 
 async function asyncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
@@ -103,6 +104,10 @@ class HomeStore {
           this.alertStore.pushSuccess(`Tokens received on ${this.web3Store.homeNet.name} for Tx ${event.returnValues.transactionHash}`)
           this.waitingForConfirmation.delete(event.returnValues.transactionHash)
         })
+
+        if(confirmationEvents.length) {
+          removePendingTransaction()
+        }
       }
 
       return homeEvents

--- a/src/stores/TxStore.js
+++ b/src/stores/TxStore.js
@@ -1,5 +1,6 @@
 import { action, observable } from "mobx";
 import { estimateGas } from './utils/web3'
+import { addPendingTransaction } from './utils/testUtils'
 
 class TxStore {
   @observable txs = []
@@ -34,6 +35,7 @@ class TxStore {
           console.log('txHash', hash)
           this.txHashToIndex[hash] = index;
           this.txs[index] = {status: 'pending', name: `Sending ${to} ${value}`, hash}
+          addPendingTransaction()
           this.getTxReceipt(hash)
         }).on('error', (e) => {
           this.alertStore.pushError(e.message);

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -1,5 +1,6 @@
 import { action, observable } from "mobx";
 import getWeb3, { getBalance, getWeb3Instance, getNetwork } from './utils/web3';
+import { balanceLoaded } from './utils/testUtils'
 
 class Web3Store {
   @observable injectedWeb3 = {};
@@ -53,6 +54,7 @@ class Web3Store {
     try {
       this.defaultAccount.homeBalance = await getBalance(this.homeWeb3, this.defaultAccount.address)
       this.defaultAccount.foreignBalance = await getBalance(this.foreignWeb3, this.defaultAccount.address)
+      balanceLoaded()
     } catch(e){
       this.alertStore.pushError(e)
     }

--- a/src/stores/utils/testUtils.js
+++ b/src/stores/utils/testUtils.js
@@ -1,0 +1,21 @@
+let balanceCount = 0
+let pendingTransaction = 0
+
+export const balanceLoaded = () => {
+  balanceCount++
+  if(balanceCount > 1) {
+    document.getElementById('root').classList.add('web3-loaded')
+  }
+}
+
+export const addPendingTransaction = () => {
+  pendingTransaction++
+  document.getElementById('root').classList.add('pending-transaction')
+}
+
+export const removePendingTransaction = () => {
+  pendingTransaction--
+  if(!pendingTransaction) {
+    document.getElementById('root').classList.remove('pending-transaction')
+  }
+}


### PR DESCRIPTION
On the div element with `id="root"` which is where the app is mounted I added the following class attributes:

- `web3-loaded`: Will be added when both, home and foreign balances are loaded.
- `pending-transaction`: Will be added when a transaction is send. Will be removed when the tokens are received on the other chain. If there is more than one pending transaction, the class attribute will be removed when all transactions are finished.

Does this works for you @dennis00010011b  @rstormsf ? Please tell me if I need to change the logic on any of the tags

Closes #38 