### PR TITLE
quick hack to change name and increase speed for tx

### DIFF
--- a/src/stores/GasPriceStore.js
+++ b/src/stores/GasPriceStore.js
@@ -20,7 +20,7 @@ class GasPriceStore {
   }
 
   @computed get standardInHex() {
-    const toWei = Web3Utils.toWei(this.gasPrices.standard.toString(), 'gwei')
+    const toWei = Web3Utils.toWei(this.gasPrices.fast.toString(), 'gwei')
     return Web3Utils.toHex(toWei)
   }
 }

--- a/src/stores/utils/web3.js
+++ b/src/stores/utils/web3.js
@@ -44,12 +44,12 @@ const getWeb3 = () => {
 export default getWeb3
 
 const networks = {
-  1: 'Main Net',
+  1: 'Network',
   3: 'Ropsten',
   4: 'Rinkeby',
   42:'Kovan',
   77:'Sokol',
-  99:'Main Net'
+  99:'Network'
 }
 
 const explorers = {


### PR DESCRIPTION
1. After feedback we decided that POA Mainnet and ETH mainnet should be named `Network`
2. GasPrice should be `fast` from oracle

