### PR TITLE
Add Exit Confirmation while loading

### DIFF
--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { inject, observer } from "mobx-react";
 import loadingLogo from '../assets/images/logos/logo-loader.svg'
 import { ProgressRing } from './ProgressRing'
+import { PreventExit } from './PreventExit'
 
 @inject("RootStore")
 @observer
@@ -22,6 +23,7 @@ export class Loading extends React.Component {
         {loadingStepIndex === 0 && (<img className="loading" src={loadingLogo} alt="loading"/>)}
         {loadingStepIndex === 0 && <div className="loading-i" />}
         {loadingStepIndex > 0 && (<div className="loading-text">{loadingSteps[loadingStepIndex]}</div>)}
+        {alertStore.showLoading && <PreventExit />}
       </div>
     )
   }

--- a/src/components/PreventExit.js
+++ b/src/components/PreventExit.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react'
+
+export class PreventExit extends Component {
+  onUnload = (e) => {
+    e.returnValue = "Are you sure?"
+  }
+
+  componentDidMount () {
+    window.addEventListener('beforeunload', this.onUnload)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('beforeunload', this.onUnload)
+  }
+
+  render () {
+    return <div />
+  }
+}


### PR DESCRIPTION
This pull request adds a confirmation alert before closing the page tab or browser while the app is on loading state (i.e. a transfer is being made) to prevent the user closing the page accidentally.