### PR TITLE
Update intervals timeout

### DIFF
--- a/src/stores/ForeignStore.js
+++ b/src/stores/ForeignStore.js
@@ -64,7 +64,7 @@ class ForeignStore {
       this.getEvents()
       this.getTokenBalance()
       this.getCurrentLimit()
-    }, 5000)
+    }, 15000)
   }
 
   @action

--- a/src/stores/HomeStore.js
+++ b/src/stores/HomeStore.js
@@ -57,9 +57,11 @@ class HomeStore {
     setInterval(() => {
       this.getEvents()
       this.getBalance()
-      this.getCurrentLimit()
       this.getBlockNumber()
     }, 5000)
+    setInterval(() => {
+      this.getCurrentLimit()
+    }, 10000)
   }
 
   @action

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -5,7 +5,7 @@ import swal from 'sweetalert'
 
 class Web3Store {
   @observable injectedWeb3 = {};
-  @observable defaultAccount = {address: '', homeBalance: '', foreignBalance: ''};
+  @observable defaultAccount = {address: '', homeBalance: ''};
 
   @observable homeWeb3 = {};
   @observable foreignWeb3 = {};
@@ -32,7 +32,7 @@ class Web3Store {
       this.getBalances(false)
       setInterval(() => {
         this.getBalances(true)
-      }, 1000)
+      }, 3000)
     }).catch((e) => {
       console.error(e,'web3 not loaded')
       this.errors.push(e.message)
@@ -79,7 +79,6 @@ class Web3Store {
         this.defaultAccount.address = accounts[0]
       }
       this.defaultAccount.homeBalance = await getBalance(this.homeWeb3, this.defaultAccount.address)
-      this.defaultAccount.foreignBalance = await getBalance(this.foreignWeb3, this.defaultAccount.address)
       if(accountUpdated) {
         await this.rootStore.foreignStore.getTokenBalance()
         this.alertStore.setLoading(false)


### PR DESCRIPTION
To reduce the number request here are some changes I made:
- Removed request to obtain user foreign balance on web3Store, because it was not used.
- Updated foreignStore interval to 15 seconds. Originally it was at 15, but it was changed to 5 because of latency on loading balance on account change on this PR https://github.com/poanetwork/bridge-ui/pull/59 . Later on this PR https://github.com/poanetwork/bridge-ui/pull/118 loading screen was added for account change and foreign balance is called too there, so it's I think it's ok to change foreign interval back to 15 seconds again.  
- Updated web3Store interval from 1 second to 3 seconds to check Home user balance and detect account change. This affects on how long it takes to the app to detect account changes on metamask.
- Made a separate interval on homeStore to call getCurrentLimit() every 10 seconds instead of 5 seconds.

I couldn't detect any other request that can be removed, also new intervals values are open to discussion. 

Closes #125 