### PR TITLE
Support status in tx receipt that can be boolean 

### DIFF
--- a/src/stores/TxStore.js
+++ b/src/stores/TxStore.js
@@ -105,7 +105,7 @@ class TxStore {
     const { toBN } = web3.utils
     web3.eth.getTransactionReceipt(hash, (error, res) => {
       if(res && res.blockNumber){
-        if(toBN(res.status).eq(toBN(1))){
+        if(res.status === true || toBN(res.status).eq(toBN(1))){
           if(this.web3Store.metamaskNet.id === this.web3Store.homeNet.id.toString()) {
             const blockConfirmations = this.homeStore.latestBlockNumber - res.blockNumber
             if(blockConfirmations >= 8) {


### PR DESCRIPTION
For some setup of eip in spec.conf of a poa chain. ( with parity v2.2.5 and this conf for instance https://github.com/paritytech/parity-deploy/blob/master/config/spec/params/aura).
 It creates boolean status in transaction receipt instead of number. And It raises this error 
<img width="1247" alt="receipt-status-error" src="https://user-images.githubusercontent.com/1752810/50351070-51820780-0541-11e9-90ae-316e6846c59c.png"> This commit fix it and cover both cases with boolean or number in transaction receipt status. 
