### PR TITLE
Fix incorrect network name in success window

### DIFF
--- a/src/stores/TxStore.js
+++ b/src/stores/TxStore.js
@@ -120,7 +120,7 @@ class TxStore {
                   const unitReceived = getUnit(this.rootStore.bridgeMode).unitForeign
                   setTimeout(() => {
                       this.alertStore.pushSuccess(
-                        `${unitReceived} received on ${this.homeStore.networkName}`,
+                        `${unitReceived} received on ${this.foreignStore.networkName}`,
                         this.alertStore.FOREIGN_TRANSFER_SUCCESS
                       )
                     }
@@ -150,7 +150,7 @@ class TxStore {
                     const unitReceived = getUnit(this.rootStore.bridgeMode).unitHome
                     setTimeout(() => {
                         this.alertStore.pushSuccess(
-                          `${unitReceived} received on ${this.foreignStore.networkName}`,
+                          `${unitReceived} received on ${this.homeStore.networkName}`,
                           this.alertStore.HOME_TRANSFER_SUCCESS
                         )
                       }

--- a/src/stores/utils/bridgeMode.js
+++ b/src/stores/utils/bridgeMode.js
@@ -53,8 +53,8 @@ export const getUnit = (bridgeMode) => {
     unitHome = 'Tokens'
     unitForeign = 'Tokens'
   } else if (bridgeMode === BRIDGE_MODES.ERC_TO_NATIVE) {
-    unitHome = 'Tokens'
-    unitForeign = 'Native coins'
+    unitHome = 'Native coins'
+    unitForeign = 'Tokens'
   } else {
     throw new Error(`Unrecognized bridge mode: ${bridgeMode}`)
   }


### PR DESCRIPTION
Closes #172 

Example of success alert for `ERC20-to-Native` bridge on `Sokol-Kovan`

- Transfer from Foreign to Home
![foreign-to-home](https://user-images.githubusercontent.com/4614574/50450440-d471dc00-090c-11e9-9798-0243425a478e.png)

- Transfer from Home to Foreign
![home-to-foreign](https://user-images.githubusercontent.com/4614574/50450454-f0757d80-090c-11e9-9e4a-0568d381d21b.png)

Next examples are transfer with the following config:
```
REACT_APP_HOME_WITHOUT_EVENTS=true
REACT_APP_FOREIGN_WITHOUT_EVENTS=true
```
- Transfer from Foreign to Home
![foreign-to-home-without-events](https://user-images.githubusercontent.com/4614574/50450503-4ea26080-090d-11e9-80bd-c7378c450179.png)
 
- Transfer from Home to Foreign
![home-to-foreign-without-events](https://user-images.githubusercontent.com/4614574/50450522-6974d500-090d-11e9-9fee-9e832261f7db.png)
