### PR TITLE
breaking change in last web3js release.  fix dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-transition-group": "^2.2.1",
     "selenium-webdriver": "^3.6.0",
     "sweetalert": "^2.1.0",
-    "web3": "^1.0.0-beta.30"
+    "web3": "1.0.0-beta.30"
   },
   "scripts": {
     "build-css": "node-sass-chokidar src/assets/stylesheets/application.scss -o src/assets/stylesheets --output-style=compressed",


### PR DESCRIPTION
Last webjs introduce breaking change on existing code.
 
For instance, v1.0.0-beta.38 remove utils here : 
https://github.com/ethereum/web3.js/commit/cfd9130e544812e61b10cf1007a9cd1f0d9ec9ad

and it breaks the following code : 
https://github.com/poanetwork/bridge-ui/blob/develop/src/stores/utils/gas.js#L1

It seems, I have also have an issue with .call format change here from a string to an object and break the switch condition here : 
https://github.com/poanetwork/bridge-ui/blob/develop/src/stores/utils/bridgeMode.js#L33
as value bridgeModeHash show in the picture : 


![formatchange](https://user-images.githubusercontent.com/1752810/51844313-37440200-2315-11e9-87f9-7877d3a14a84.png)

I fix by targeting strict version : `"web3": "1.0.0-beta.30"` instead of : `"web3": "^1.0.0-beta.30"`.

Maybe a specific future web3js update to treat.
