### PR TITLE
Support transaction null status

### DIFF
--- a/src/stores/TxStore.js
+++ b/src/stores/TxStore.js
@@ -177,7 +177,7 @@ class TxStore {
   isStatusSuccess(tx) {
     const { toBN } = this.web3Store.injectedWeb3.utils
     const statusSuccess =  tx.status && (tx.status === true || toBN(tx.status).eq(toBN(1)))
-    const eventEmitted = tx.logs.length
+    const eventEmitted = tx.logs && tx.logs.length
     return statusSuccess || eventEmitted
   }
 

--- a/src/stores/TxStore.js
+++ b/src/stores/TxStore.js
@@ -103,10 +103,9 @@ class TxStore {
 
   async getTxStatus(hash) {
     const web3 = this.web3Store.injectedWeb3;
-    const { toBN } = web3.utils
     web3.eth.getTransactionReceipt(hash, (error, res) => {
       if(res && res.blockNumber){
-        if(res.status === true || toBN(res.status).eq(toBN(1))){
+        if(this.isStatusSuccess(res)){
           if(this.web3Store.metamaskNet.id === this.web3Store.homeNet.id.toString()) {
             const blockConfirmations = this.homeStore.latestBlockNumber - res.blockNumber
             if(blockConfirmations >= 8) {
@@ -173,6 +172,13 @@ class TxStore {
         this.getTxStatus(hash)
       }
     })
+  }
+
+  isStatusSuccess(tx) {
+    const { toBN } = this.web3Store.injectedWeb3.utils
+    const statusSuccess =  tx.status && (tx.status === true || toBN(tx.status).eq(toBN(1)))
+    const eventEmitted = tx.logs.length
+    return statusSuccess || eventEmitted
   }
 
 }

--- a/src/stores/__tests__/TxStore.test.js
+++ b/src/stores/__tests__/TxStore.test.js
@@ -1,0 +1,97 @@
+import TxStore from '../TxStore'
+import Web3 from 'web3'
+
+describe('TxStore', function () {
+  let txStore
+  beforeEach(() => {
+    const rootStore = {
+      web3Store: {
+        injectedWeb3: new Web3()
+      }
+    }
+    txStore = new TxStore(rootStore)
+  })
+  describe('isStatusSuccess', function () {
+    it('should return true if status field is 0x1', () => {
+      // Given
+      const tx = {
+        status: '0x1',
+        logs: []
+      }
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+
+      // Then
+      expect(result).toBeTruthy()
+    })
+    it('should return false if status field is 0x0', () => {
+      // Given
+      const tx = {
+        status: '0x0',
+        logs: []
+      }
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+
+      // Then
+      expect(result).toBeFalsy()
+    })
+    it('should work if status field is boolean', () => {
+      // Given
+      const tx = {
+        status: false,
+        logs: []
+      }
+      const tx2 = {
+        status: true,
+        logs: []
+      }
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+      const result2 = txStore.isStatusSuccess(tx2)
+
+      // Then
+      expect(result).toBeFalsy()
+      expect(result2).toBeTruthy()
+    })
+    it('should return true if status field not present and logs length > 0', () => {
+      // Given
+      const tx = {
+        logs: [
+            {}
+          ]
+      }
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+
+      // Then
+      expect(result).toBeTruthy()
+    })
+    it('should return false if status field not present and no logs', () => {
+      // Given
+      const tx = {
+        logs: []
+      }
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+
+      // Then
+      expect(result).toBeFalsy()
+    })
+    it('should return false if status field not present and logs field not present', () => {
+      // Given
+      const tx = {}
+
+      // When
+      const result = txStore.isStatusSuccess(tx)
+
+      // Then
+      expect(result).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
If `status` attribute is not present on transaction receipt, it will also check on the length of `logs` attribute to determine that the transaction was successful