### PR TITLE
Fix get fee methods for production build

### DIFF
--- a/src/stores/utils/contract.js
+++ b/src/stores/utils/contract.js
@@ -96,12 +96,12 @@ export const getFeeManagerMode = (contract) => contract.methods.getFeeManagerMod
 
 export const getHomeFee = async (contract) => {
   const feeInWei = await contract.methods.getHomeFee().call()
-  return new BN(fromWei(feeInWei))
+  return new BN(fromWei(feeInWei.toString()))
 }
 
 export const getForeignFee = async (contract) => {
   const feeInWei = await contract.methods.getForeignFee().call()
-  return new BN(fromWei(feeInWei))
+  return new BN(fromWei(feeInWei.toString()))
 }
 
 export const getFeeToApply = (homeFeeManager, foreignFeeManager, homeToForeignDirection) => {


### PR DESCRIPTION
Fix the error that appears on the production build of the app when trying to convert fee values:
```
Uncaught (in promise) Error: Please pass numbers as strings or BigNumber objects to avoid precision errors.
    at t.fromWei (web3-utils.umd.js:541)
    at contract.js:104
    at _ (runtime.js:62)
    at Generator._invoke (runtime.js:288)
    at Generator.t.(/anonymous function) [as next] (https://wetc.app/static/js/2.e710153c.chunk.js:1:649390)
    at r (asyncToGenerator.js:3)
    at s (asyncToGenerator.js:25)
```