### PR TITLE
Fix e2e tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ COPY package.json .
 COPY package-lock.json .
 COPY . .
 RUN npm install
+RUN npm run postinstall


### PR DESCRIPTION
On e2e tests docker is using cached layer for npm install so is not running the postinstall script. Updated the script to force running the npm script