### PR TITLE
Handling of absence eth_chainId on Web3 provider side

### DIFF
--- a/src/stores/utils/web3.js
+++ b/src/stores/utils/web3.js
@@ -98,7 +98,11 @@ export const estimateGas = async (web3, to, gasPrice, from, value, data) =>{
 }
 
 const processWeb3 = async (web3, resolve,  reject) => {
-  const netId = await web3.eth.getChainId()
+  try {
+    const netId = await web3.eth.getChainId()
+  } catch (error) {
+    reject({ type: 'chainid', message: 'Wallet does not support getting the Chain ID. Please use another wallet or specify a RPC url of a node that supports eth_chainId call' })
+  }
   const netIdName = getNetworkName(netId)
 
   console.log(`This is ${netIdName} network.`, netId)

--- a/src/stores/utils/web3.js
+++ b/src/stores/utils/web3.js
@@ -98,10 +98,11 @@ export const estimateGas = async (web3, to, gasPrice, from, value, data) =>{
 }
 
 const processWeb3 = async (web3, resolve,  reject) => {
+  let netId
   try {
-    const netId = await web3.eth.getChainId()
+    netId = await web3.eth.getChainId()
   } catch (error) {
-    reject({ type: 'chainid', message: 'Wallet does not support getting the Chain ID. Please use another wallet or specify a RPC url of a node that supports eth_chainId call' })
+    reject({ type: 'unlock', message: 'Wallet does not support getting the Chain ID. Please use another wallet or specify a RPC url of a node that supports eth_chainId call' })
   }
   const netIdName = getNetworkName(netId)
 


### PR DESCRIPTION
If a web3 provider used by the wallet does not support `eth_chainId` call the message `Wallet account rejected by user. You need to unlock your wallet. Please refresh the page and click 'Connect' button in your wallet popup` appears. It does not clarify the issue. 

That's why it is suggested to handle errors appeared when `getChainId` called and provide more precise explanation what it is necessary to do to address the issue.
