### PR TITLE
Fix unit tests on travis CI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "test": {
+      "plugins": [
+        [
+          "@babel/plugin-proposal-decorators",
+          {
+            "legacy": true
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Unit test were failing because they were not able to process decorator syntax. After this fix, Travis CI should pass