### PR TITLE
Improve error message for gas price oracle on V1

### DIFF
--- a/src/stores/GasPriceStore.js
+++ b/src/stores/GasPriceStore.js
@@ -17,7 +17,7 @@ class GasPriceStore {
       console.log(data)
       this.gasPrices = data;
     }).catch((e) => {
-      this.alertStore.pushError(`Gas price oracle is not available`)
+      this.alertStore.pushError(`Gas price oracle is not available, please try returning to this page after a couple of minutes.`)
     })
   }
 

--- a/src/stores/GasPriceStore.js
+++ b/src/stores/GasPriceStore.js
@@ -17,7 +17,7 @@ class GasPriceStore {
       console.log(data)
       this.gasPrices = data;
     }).catch((e) => {
-      this.alertStore.pushError(e)
+      this.alertStore.pushError(`Gas price oracle is not available`)
     })
   }
 


### PR DESCRIPTION
Related to https://github.com/poanetwork/tokenbridge/issues/84

New error message
![gaspriceError](https://user-images.githubusercontent.com/4614574/59053794-9b994400-8868-11e9-917d-49deeaf21540.png)
